### PR TITLE
Fixed unicode issue in choose_plugin.py

### DIFF
--- a/plugins/choose_plugin.py
+++ b/plugins/choose_plugin.py
@@ -11,7 +11,7 @@ class Plugin(BasePlugin):
     @hook
     def choose_trigger(self, msg, args, argstr):
         argstr = argstr.replace(' or ', ',').replace(',or ', ',')
-        choices = [x for x in map(str.strip, argstr.split(',')) if x]
+        choices = [x for x in map(unicode.strip, argstr.split(',')) if x]
         if not choices:
             responses = [
                 "Choices choices.. which do I choose from.  Oh right, I don't.",


### PR DESCRIPTION
str object was used instead of unicode in map() function, causing conflict with recent unicode updates to the core functionality.